### PR TITLE
Populate controller status in firewall resource.

### DIFF
--- a/controllers/monitor/reconcile.go
+++ b/controllers/monitor/reconcile.go
@@ -65,6 +65,8 @@ func (c *controller) updateFirewallStatus(r *controllers.Ctx[*v2.FirewallMonitor
 				Updated:       r.Target.ControllerStatus.Updated,
 			}
 
+			fw.Status.ControllerStatus = connection
+
 			if connection.Updated.Time.IsZero() {
 				cond := v2.NewCondition(v2.FirewallControllerConnected, v2.ConditionFalse, "NotConnected", "Controller has not yet connected.")
 				fw.Status.Conditions.Set(cond)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -776,6 +776,14 @@ var _ = Context("integration test", Ordered, func() {
 				}, 5*time.Second)
 				Expect(mon.MachineStatus.MachineID).To(Equal(*readyFirewall.ID))
 			})
+
+			It("should populate the controller status field in the firewall resource", func() {
+				var fw = fw.DeepCopy()
+				Eventually(func() *v2.ControllerConnection {
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(fw), fw)).To(Succeed())
+					return fw.Status.ControllerStatus
+				}, 15*time.Second, interval).Should(Not(BeNil()), "controller connection was not synced to firewall resource")
+			})
 		})
 	})
 


### PR DESCRIPTION
```
❯ k get fw2 -o wide
NAME                                     PHASE     MACHINE ID                             LAST EVENT    AGE   SPEC VERSION   ACTUAL VERSION
shoot--p66bdb--inttest0-firewall-91612   Running   c1545200-be84-11e9-8000-3cecef22f916   Phoned Home   10m   4912946        4912946
```