### PR TITLE
Factor out default firewall reconcile interval into a constant.

### DIFF
--- a/api/v2/defaults/defaults.go
+++ b/api/v2/defaults/defaults.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+const (
+	DefaultFirewallReconcileInterval = "10s"
+)
+
 type (
 	firewallDefaulter struct {
 		c   *config.ControllerConfig
@@ -163,7 +167,7 @@ func (r *firewallDeploymentDefaulter) Default(ctx context.Context, obj runtime.O
 
 func defaultFirewallSpec(f *v2.FirewallSpec) {
 	if f.Interval == "" {
-		f.Interval = "10s"
+		f.Interval = DefaultFirewallReconcileInterval
 	}
 }
 

--- a/api/v2/defaults/defaults_test.go
+++ b/api/v2/defaults/defaults_test.go
@@ -79,7 +79,7 @@ package defaults
 // 							},
 // 						},
 // 						Spec: v2.FirewallSpec{
-// 							Interval:      "10s",
+// 							Interval:      DefaultFirewallReconcileInterval,
 // 							Userdata:      `{"ignition":{"config":{},"security":{"tls":{}},"timeouts":{},"version":"2.3.0"},"networkd":{},"passwd":{},"storage":{"files":[{"filesystem":"root","group":{"id":0},"path":"/etc/firewall-controller/.kubeconfig","user":{"id":0},"contents":{"source":"data:,apiVersion%3A%20v1%0Aclusters%3A%0A-%20cluster%3A%0A%20%20%20%20certificate-authority-data%3A%20YS1jYS1jcnQ%3D%0A%20%20%20%20server%3A%20https%3A%2F%2Fseed-api%0A%20%20name%3A%20b%0Acontexts%3A%0A-%20context%3A%0A%20%20%20%20cluster%3A%20b%0A%20%20%20%20user%3A%20b%0A%20%20name%3A%20b%0Acurrent-context%3A%20b%0Akind%3A%20Config%0Apreferences%3A%20%7B%7D%0Ausers%3A%0A-%20name%3A%20b%0A%20%20user%3A%0A%20%20%20%20token%3A%20a-token%0A","verification":{}},"mode":384}]},"systemd":{"units":[{"enable":true,"enabled":true,"name":"firewall-controller.service"},{"enable":true,"enabled":true,"name":"droptailer.service"}]}}`,
 // 							SSHPublicKeys: []string{"ssh-public-key"},
 // 						},

--- a/api/v2/validation/firewall_test.go
+++ b/api/v2/validation/firewall_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
+	"github.com/metal-stack/firewall-controller-manager/api/v2/defaults"
 	"github.com/metal-stack/metal-lib/pkg/testcommon"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +24,7 @@ func Test_firewallValidator_ValidateCreate(t *testing.T) {
 			},
 		},
 		Spec: v2.FirewallSpec{
-			Interval:                "10s",
+			Interval:                defaults.DefaultFirewallReconcileInterval,
 			ControllerURL:           "https://metal-stack.io/controller.img",
 			ControllerVersion:       "v",
 			NftablesExporterURL:     "http://exporter.tar.gz",
@@ -117,7 +118,7 @@ func Test_firewallValidator_ValidateUpdate(t *testing.T) {
 					},
 				},
 				Spec: v2.FirewallSpec{
-					Interval:                "10s",
+					Interval:                defaults.DefaultFirewallReconcileInterval,
 					ControllerURL:           "https://metal-stack.io/controller.img",
 					ControllerVersion:       "v",
 					NftablesExporterURL:     "http://exporter.tar.gz",
@@ -147,7 +148,7 @@ func Test_firewallValidator_ValidateUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: v2.FirewallSpec{
-					Interval:                "10s",
+					Interval:                defaults.DefaultFirewallReconcileInterval,
 					ControllerURL:           "https://metal-stack.io/controller.img",
 					ControllerVersion:       "v",
 					NftablesExporterURL:     "http://exporter.tar.gz",

--- a/api/v2/validation/firewalldeployment_test.go
+++ b/api/v2/validation/firewalldeployment_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
+	"github.com/metal-stack/firewall-controller-manager/api/v2/defaults"
 	"github.com/metal-stack/metal-lib/pkg/testcommon"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func Test_firewallDeploymentValidator_ValidateCreate(t *testing.T) {
 					},
 				},
 				Spec: v2.FirewallSpec{
-					Interval:                "10s",
+					Interval:                defaults.DefaultFirewallReconcileInterval,
 					ControllerURL:           "https://metal-stack.io/controller.img",
 					ControllerVersion:       "v",
 					NftablesExporterURL:     "http://exporter.tar.gz",
@@ -116,7 +117,7 @@ func Test_firewallDeploymentValidator_ValidateUpdate(t *testing.T) {
 					},
 				},
 				Spec: v2.FirewallSpec{
-					Interval:                "10s",
+					Interval:                defaults.DefaultFirewallReconcileInterval,
 					ControllerURL:           "https://metal-stack.io/controller.img",
 					ControllerVersion:       "v",
 					NftablesExporterURL:     "http://exporter.tar.gz",

--- a/api/v2/validation/firewallset_test.go
+++ b/api/v2/validation/firewallset_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
+	"github.com/metal-stack/firewall-controller-manager/api/v2/defaults"
 	"github.com/metal-stack/metal-lib/pkg/testcommon"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func Test_firewalSetValidator_ValidateCreate(t *testing.T) {
 					},
 				},
 				Spec: v2.FirewallSpec{
-					Interval:                "10s",
+					Interval:                defaults.DefaultFirewallReconcileInterval,
 					ControllerURL:           "https://metal-stack.io/controller.img",
 					ControllerVersion:       "v",
 					NftablesExporterURL:     "http://exporter.tar.gz",
@@ -141,7 +142,7 @@ func Test_firewallSetValidator_ValidateUpdate(t *testing.T) {
 					},
 				},
 				Spec: v2.FirewallSpec{
-					Interval:                "10s",
+					Interval:                defaults.DefaultFirewallReconcileInterval,
 					ControllerURL:           "https://metal-stack.io/controller.img",
 					ControllerVersion:       "v",
 					NftablesExporterURL:     "http://exporter.tar.gz",

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
+	"github.com/metal-stack/firewall-controller-manager/api/v2/defaults"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -140,6 +141,7 @@ var _ = Context("integration test", Ordered, func() {
 						ControllerVersion:       "v2.0.0",
 						NftablesExporterURL:     "http://exporter.tar.gz",
 						NftablesExporterVersion: "v1.0.0",
+						Interval:                defaults.DefaultFirewallReconcileInterval,
 					},
 				},
 			},
@@ -271,7 +273,6 @@ var _ = Context("integration test", Ordered, func() {
 
 			It("should inherit the spec from the set", func() {
 				wantSpec := set.Spec.Template.Spec.DeepCopy()
-				wantSpec.Interval = "10s"
 				Expect(&fw.Spec).To(BeComparableTo(wantSpec))
 			})
 
@@ -357,7 +358,6 @@ var _ = Context("integration test", Ordered, func() {
 
 			It("should inherit the spec from the deployement", func() {
 				wantSpec := deployment.Spec.Template.Spec.DeepCopy()
-				wantSpec.Interval = "10s"
 				Expect(&set.Spec.Template.Spec).To(BeComparableTo(wantSpec))
 			})
 
@@ -513,7 +513,6 @@ var _ = Context("integration test", Ordered, func() {
 
 			It("should inherit the spec from the set", func() {
 				wantSpec := set.Spec.Template.Spec.DeepCopy()
-				wantSpec.Interval = "10s"
 				Expect(&fw.Spec).To(BeComparableTo(wantSpec))
 			})
 
@@ -638,7 +637,6 @@ var _ = Context("integration test", Ordered, func() {
 			It("should inherit the spec from the deployement", func() {
 				wantSpec := deployment.Spec.Template.Spec.DeepCopy()
 				wantSpec.Size = "n2-medium-x86"
-				wantSpec.Interval = "10s"
 				Expect(&set.Spec.Template.Spec).To(BeComparableTo(wantSpec))
 			})
 


### PR DESCRIPTION
`10s` is all over the place. Also the integration test from FITS uses this value a lot to wait for firewall reconciles, so we can use the constant there, too.