### PR TITLE
Requeue reconciliation on status error.

### DIFF
--- a/controllers/firewall/controller.go
+++ b/controllers/firewall/controller.go
@@ -23,10 +23,11 @@ import (
 )
 
 type controller struct {
-	c            *config.ControllerConfig
-	log          logr.Logger
-	recorder     record.EventRecorder
-	networkCache *cache.Cache[string, *models.V1NetworkResponse]
+	c             *config.ControllerConfig
+	log           logr.Logger
+	recorder      record.EventRecorder
+	networkCache  *cache.Cache[string, *models.V1NetworkResponse]
+	firewallCache *cache.Cache[*v2.Firewall, []*models.V1FirewallResponse]
 }
 
 func SetupWithManager(log logr.Logger, recorder record.EventRecorder, mgr ctrl.Manager, c *config.ControllerConfig) error {
@@ -39,6 +40,19 @@ func SetupWithManager(log logr.Logger, recorder record.EventRecorder, mgr ctrl.M
 			if err != nil {
 				return nil, fmt.Errorf("network find error: %w", err)
 			}
+			return resp.Payload, nil
+		}),
+		// the cache is only very short but on quickly repeated status updates, this should prevent the metal-api from being flooded
+		firewallCache: cache.New(5*time.Second, func(ctx context.Context, fw *v2.Firewall) ([]*models.V1FirewallResponse, error) {
+			resp, err := c.GetMetal().Firewall().FindFirewalls(firewall.NewFindFirewallsParams().WithBody(&models.V1FirewallFindRequest{
+				AllocationName:    fw.Name,
+				AllocationProject: fw.Spec.Project,
+				Tags:              []string{c.GetClusterTag()},
+			}).WithContext(ctx), nil)
+			if err != nil {
+				return nil, fmt.Errorf("firewall find error: %w", err)
+			}
+
 			return resp.Payload, nil
 		}),
 	})
@@ -78,17 +92,4 @@ func (c *controller) New() *v2.Firewall {
 
 func (c *controller) SetStatus(reconciled *v2.Firewall, refetched *v2.Firewall) {
 	refetched.Status = reconciled.Status
-}
-
-func (c *controller) findAssociatedFirewalls(ctx context.Context, fw *v2.Firewall) ([]*models.V1FirewallResponse, error) {
-	resp, err := c.c.GetMetal().Firewall().FindFirewalls(firewall.NewFindFirewallsParams().WithBody(&models.V1FirewallFindRequest{
-		AllocationName:    fw.Name,
-		AllocationProject: fw.Spec.Project,
-		Tags:              []string{c.c.GetClusterTag()},
-	}).WithContext(ctx), nil)
-	if err != nil {
-		return nil, fmt.Errorf("firewall find error: %w", err)
-	}
-
-	return resp.Payload, nil
 }

--- a/controllers/firewall/delete.go
+++ b/controllers/firewall/delete.go
@@ -18,7 +18,7 @@ func (c *controller) Delete(r *controllers.Ctx[*v2.Firewall]) error {
 		return fmt.Errorf("unable to delete firewall monitor: %w", err)
 	}
 
-	fws, err := c.findAssociatedFirewalls(r.Ctx, r.Target)
+	fws, err := c.firewallCache.Get(r.Ctx, r.Target)
 	if err != nil {
 		return controllers.RequeueAfter(10*time.Second, err.Error())
 	}

--- a/controllers/firewall/reconcile.go
+++ b/controllers/firewall/reconcile.go
@@ -35,7 +35,7 @@ func (c *controller) Reconcile(r *controllers.Ctx[*v2.Firewall]) error {
 		}
 	}()
 
-	fws, err := c.findAssociatedFirewalls(r.Ctx, r.Target)
+	fws, err := c.firewallCache.Get(r.Ctx, r.Target)
 	if err != nil {
 		return controllers.RequeueAfter(10*time.Second, err.Error())
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -253,6 +253,7 @@ var _ = Context("integration test", Ordered, func() {
 
 			It("should allow an update of the firewall monitor", func() {
 				// simulating a firewall-controller updating the resource
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mon), mon)).To(Succeed()) // refetch
 				mon.ControllerStatus = &v2.ControllerStatus{
 					Updated: metav1.NewTime(time.Now()),
 				}


### PR DESCRIPTION
For the firewall resource we may have to wait 2 minutes until the next attempt, which is also why sometimes integration tests are timing out.