### PR TITLE
Fix token updater shutting down on error.

### DIFF
--- a/api/v2/helper/shoot_access.go
+++ b/api/v2/helper/shoot_access.go
@@ -186,7 +186,7 @@ func NewShootAccessTokenUpdater(s *ShootAccessHelper, tokenDir string) (*ShootAc
 func (s *ShootAccessTokenUpdater) UpdateContinuously(log logr.Logger, stop context.Context) error {
 	log.Info("updating token file", "path", s.s.tokenPath)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(stop, 3*time.Second)
 	_, token, err := s.s.ReadTokenSecret(ctx)
 	cancel()
 	if err != nil {
@@ -209,7 +209,7 @@ func (s *ShootAccessTokenUpdater) UpdateContinuously(log logr.Logger, stop conte
 			case <-ticker.C:
 				log.Info("updating token file", "path", s.s.tokenPath)
 
-				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				ctx, cancel := context.WithTimeout(stop, 3*time.Second)
 				_, token, err := s.s.ReadTokenSecret(ctx)
 				cancel()
 				if err != nil {

--- a/api/v2/helper/shoot_access.go
+++ b/api/v2/helper/shoot_access.go
@@ -186,7 +186,7 @@ func NewShootAccessTokenUpdater(s *ShootAccessHelper, tokenDir string) (*ShootAc
 func (s *ShootAccessTokenUpdater) UpdateContinuously(log logr.Logger, stop context.Context) error {
 	log.Info("updating token file", "path", s.s.tokenPath)
 
-	ctx, cancel := context.WithTimeout(stop, 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	_, token, err := s.s.ReadTokenSecret(ctx)
 	cancel()
 	if err != nil {
@@ -209,18 +209,18 @@ func (s *ShootAccessTokenUpdater) UpdateContinuously(log logr.Logger, stop conte
 			case <-ticker.C:
 				log.Info("updating token file", "path", s.s.tokenPath)
 
-				ctx, cancel := context.WithTimeout(stop, 3*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 				_, token, err := s.s.ReadTokenSecret(ctx)
 				cancel()
 				if err != nil {
 					log.Error(err, "unable to read token secret")
-					break
+					continue
 				}
 
 				err = os.WriteFile(s.s.tokenPath, []byte(token), 0600)
 				if err != nil {
 					log.Error(err, "unable to update token file")
-					break
+					continue
 				}
 
 				log.Info("updated token file successfully, next update in 5 minutes")


### PR DESCRIPTION
Could be the solution for https://github.com/metal-stack/firewall-controller/issues/147.