### PR TITLE
Remove orphan deletion.

### DIFF
--- a/controllers/set/delete.go
+++ b/controllers/set/delete.go
@@ -6,11 +6,7 @@ import (
 
 	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
 	"github.com/metal-stack/firewall-controller-manager/controllers"
-	"github.com/metal-stack/metal-go/api/client/firewall"
-	"github.com/metal-stack/metal-go/api/client/machine"
-	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *controller) Delete(r *controllers.Ctx[*v2.FirewallSet]) error {
@@ -75,61 +71,4 @@ func (c *controller) deleteAfterTimeout(r *controllers.Ctx[*v2.FirewallSet], fws
 	}
 
 	return result, nil
-}
-
-// deletePhysicalOrphans checks in the backend if there are firewall entities that belong to the controller
-// event though there is no corresponding firewall resource managed by this controller.
-//
-// such firewalls will be deleted in the backend.
-func (c *controller) deletePhysicalOrphans(r *controllers.Ctx[*v2.FirewallSet]) error {
-	resp, err := c.c.GetMetal().Firewall().FindFirewalls(firewall.NewFindFirewallsParams().WithBody(&models.V1FirewallFindRequest{
-		AllocationProject: r.Target.Spec.Template.Spec.Project,
-		Tags:              []string{c.c.GetClusterTag(), v2.FirewallSetTag(r.Target.Name)},
-	}).WithContext(r.Ctx), nil)
-	if err != nil {
-		r.Log.Error(err, "unable to retrieve firewalls for orphan checking, backing off...")
-		return controllers.RequeueAfter(10*time.Second, "backing off")
-	}
-
-	if len(resp.Payload) == 0 {
-		return nil
-	}
-
-	fws := &v2.FirewallList{}
-	err = c.c.GetSeedClient().List(r.Ctx, fws, client.InNamespace(c.c.GetSeedNamespace()))
-	if err != nil {
-		return err
-	}
-
-	ownedFirewalls, _, err := controllers.GetOwnedResources(r.Ctx, c.c.GetSeedClient(), r.Target.Spec.Selector, r.Target, &v2.FirewallList{}, func(fl *v2.FirewallList) []*v2.Firewall {
-		return fl.GetItems()
-	})
-	if err != nil {
-		return fmt.Errorf("unable to get owned firewalls: %w", err)
-	}
-
-	existingNames := map[string]bool{}
-	for _, fw := range ownedFirewalls {
-		existingNames[fw.Name] = true
-	}
-
-	for _, fw := range resp.Payload {
-		if fw.Allocation == nil || fw.Allocation.Name == nil {
-			continue
-		}
-		if _, ok := existingNames[*fw.Allocation.Name]; ok {
-			continue
-		}
-
-		r.Log.Info("found physical orphan firewall, deleting", "firewall-name", *fw.Allocation.Name, "id", *fw.ID, "non-orphans", existingNames)
-
-		_, err = c.c.GetMetal().Machine().FreeMachine(machine.NewFreeMachineParams().WithID(*fw.ID), nil)
-		if err != nil {
-			return fmt.Errorf("error deleting orphaned firewall: %w", err)
-		}
-
-		c.recorder.Eventf(r.Target, "Normal", "Delete", "deleted orphaned firewall %s id %s", *fw.Allocation.Name, *fw.ID)
-	}
-
-	return nil
 }

--- a/controllers/set/reconcile.go
+++ b/controllers/set/reconcile.go
@@ -83,7 +83,7 @@ func (c *controller) Reconcile(r *controllers.Ctx[*v2.FirewallSet]) error {
 		return err
 	}
 
-	return c.deletePhysicalOrphans(r)
+	return nil
 }
 
 func pop[E any](slice []E) (E, []E) {

--- a/controllers/set/suite_test.go
+++ b/controllers/set/suite_test.go
@@ -13,13 +13,10 @@ import (
 	"github.com/metal-stack/firewall-controller-manager/controllers"
 	"github.com/metal-stack/firewall-controller-manager/controllers/firewall"
 	"github.com/metal-stack/firewall-controller-manager/controllers/set"
-	metalfirewall "github.com/metal-stack/metal-go/api/client/firewall"
-	"github.com/metal-stack/metal-go/api/models"
 	metalclient "github.com/metal-stack/metal-go/test/client"
 	"github.com/metal-stack/metal-lib/pkg/tag"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/mock"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -90,12 +87,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	_, metalClient := metalclient.NewMetalMockClient(testingT, &metalclient.MetalMockFns{
-		Firewall: func(m *mock.Mock) {
-			// muting the orphan controller
-			m.On("FindFirewalls", mock.Anything, mock.Anything).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}, nil)
-		},
-	})
+	_, metalClient := metalclient.NewMetalMockClient(testingT, &metalclient.MetalMockFns{})
 
 	cc, err := controllerconfig.New(&controllerconfig.NewControllerConfig{
 		SeedClient:        k8sClient,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -16,7 +16,6 @@ import (
 
 	testcommon "github.com/metal-stack/firewall-controller-manager/integration/common"
 
-	"github.com/metal-stack/metal-go/api/client/firewall"
 	metalfirewall "github.com/metal-stack/metal-go/api/client/firewall"
 	"github.com/metal-stack/metal-go/api/client/machine"
 	"github.com/metal-stack/metal-go/api/client/network"
@@ -159,20 +158,7 @@ var _ = Context("integration test", Ordered, func() {
 			swapMetalClient(&metalclient.MetalMockFns{
 				Firewall: func(m *mock.Mock) {
 					m.On("AllocateFirewall", mock.Anything, nil).Return(&metalfirewall.AllocateFirewallOK{Payload: firewall1}, nil).Maybe()
-
-					// we need to filter the orphan controller as it would delete the firewall
-					call := m.On("FindFirewalls", mock.Anything, mock.Anything).Maybe()
-					call.Run(func(args mock.Arguments) {
-						resp := &metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}
-						params, ok := args.Get(0).(*firewall.FindFirewallsParams)
-						if !ok {
-							panic(fmt.Sprintf("unexpected type: %T", args.Get(0)))
-						}
-						if params.Body.AllocationName != "" {
-							resp.Payload = append(resp.Payload, firewall1)
-						}
-						call.ReturnArguments = mock.Arguments{resp, nil}
-					})
+					m.On("FindFirewalls", mock.Anything, nil).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{firewall1}}, nil).Maybe()
 				},
 				Network: func(m *mock.Mock) {
 					m.On("FindNetwork", mock.Anything, nil).Return(&network.FindNetworkOK{Payload: network1}, nil).Maybe()
@@ -193,20 +179,7 @@ var _ = Context("integration test", Ordered, func() {
 		swapMetalClient(&metalclient.MetalMockFns{
 			Firewall: func(m *mock.Mock) {
 				m.On("AllocateFirewall", mock.Anything, nil).Return(&metalfirewall.AllocateFirewallOK{Payload: firewall1}, nil).Maybe()
-
-				// we need to filter the orphan controller as it would delete the firewall
-				call := m.On("FindFirewalls", mock.Anything, mock.Anything).Maybe()
-				call.Run(func(args mock.Arguments) {
-					resp := &metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}
-					params, ok := args.Get(0).(*firewall.FindFirewallsParams)
-					if !ok {
-						panic(fmt.Sprintf("unexpected type: %T", args.Get(0)))
-					}
-					if params.Body.AllocationName != "" {
-						resp.Payload = append(resp.Payload, firewall1)
-					}
-					call.ReturnArguments = mock.Arguments{resp, nil}
-				})
+				m.On("FindFirewalls", mock.Anything, nil).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{firewall1}}, nil).Maybe()
 			},
 			Network: func(m *mock.Mock) {
 				m.On("FindNetwork", mock.Anything, nil).Return(&network.FindNetworkOK{Payload: network1}, nil).Maybe()
@@ -454,20 +427,7 @@ var _ = Context("integration test", Ordered, func() {
 				swapMetalClient(&metalclient.MetalMockFns{
 					Firewall: func(m *mock.Mock) {
 						m.On("AllocateFirewall", mock.Anything, nil).Return(&metalfirewall.AllocateFirewallOK{Payload: installingFirewall}, nil).Maybe()
-
-						// we need to filter the orphan controller as it would delete the firewall
-						call := m.On("FindFirewalls", mock.Anything, mock.Anything).Maybe()
-						call.Run(func(args mock.Arguments) {
-							resp := &metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}
-							params, ok := args.Get(0).(*firewall.FindFirewallsParams)
-							if !ok {
-								panic(fmt.Sprintf("unexpected type: %T", args.Get(0)))
-							}
-							if params.Body.AllocationName != "" {
-								resp.Payload = append(resp.Payload, installingFirewall)
-							}
-							call.ReturnArguments = mock.Arguments{resp, nil}
-						})
+						m.On("FindFirewalls", mock.Anything, nil).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{installingFirewall}}, nil).Maybe()
 					},
 					Network: func(m *mock.Mock) {
 						m.On("FindNetwork", mock.Anything, nil).Return(&network.FindNetworkOK{Payload: network1}, nil).Maybe()
@@ -732,19 +692,7 @@ var _ = Context("integration test", Ordered, func() {
 						m.On("UpdateMachine", mock.Anything, nil).Return(&machine.UpdateMachineOK{Payload: &models.V1MachineResponse{}}, nil).Maybe()
 					},
 					Firewall: func(m *mock.Mock) {
-						// we need to filter the orphan controller as it would delete the firewall
-						call := m.On("FindFirewalls", mock.Anything, mock.Anything).Maybe()
-						call.Run(func(args mock.Arguments) {
-							resp := &metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}
-							params, ok := args.Get(0).(*firewall.FindFirewallsParams)
-							if !ok {
-								panic(fmt.Sprintf("unexpected type: %T", args.Get(0)))
-							}
-							if params.Body.AllocationName != "" {
-								resp.Payload = append(resp.Payload, readyFirewall)
-							}
-							call.ReturnArguments = mock.Arguments{resp, nil}
-						})
+						m.On("FindFirewalls", mock.Anything, nil).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{readyFirewall}}, nil).Maybe()
 					},
 					Network: func(m *mock.Mock) {
 						m.On("FindNetwork", mock.Anything, nil).Return(&network.FindNetworkOK{Payload: network1}, nil).Maybe()
@@ -885,19 +833,7 @@ var _ = Context("migration path", Ordered, func() {
 		DeferCleanup(func() {
 			swapMetalClient(&metalclient.MetalMockFns{
 				Firewall: func(m *mock.Mock) {
-					// we need to filter the orphan controller as it would delete the firewall
-					call := m.On("FindFirewalls", mock.Anything, mock.Anything).Maybe()
-					call.Run(func(args mock.Arguments) {
-						resp := &metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}
-						params, ok := args.Get(0).(*firewall.FindFirewallsParams)
-						if !ok {
-							panic(fmt.Sprintf("unexpected type: %T", args.Get(0)))
-						}
-						if params.Body.AllocationName != "" {
-							resp.Payload = append(resp.Payload, firewall1)
-						}
-						call.ReturnArguments = mock.Arguments{resp, nil}
-					})
+					m.On("FindFirewalls", mock.Anything, nil).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{firewall1}}, nil).Maybe()
 				},
 				Network: func(m *mock.Mock) {
 					m.On("FindNetwork", mock.Anything, nil).Return(&network.FindNetworkOK{Payload: network1}, nil).Maybe()
@@ -917,19 +853,7 @@ var _ = Context("migration path", Ordered, func() {
 	Describe("the migration starts", Ordered, func() {
 		swapMetalClient(&metalclient.MetalMockFns{
 			Firewall: func(m *mock.Mock) {
-				// we need to filter the orphan controller as it would delete the firewall
-				call := m.On("FindFirewalls", mock.Anything, mock.Anything).Maybe()
-				call.Run(func(args mock.Arguments) {
-					resp := &metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{}}
-					params, ok := args.Get(0).(*firewall.FindFirewallsParams)
-					if !ok {
-						panic(fmt.Sprintf("unexpected type: %T", args.Get(0)))
-					}
-					if params.Body.AllocationName != "" {
-						resp.Payload = append(resp.Payload, firewall1)
-					}
-					call.ReturnArguments = mock.Arguments{resp, nil}
-				})
+				m.On("FindFirewalls", mock.Anything, nil).Return(&metalfirewall.FindFirewallsOK{Payload: []*models.V1FirewallResponse{firewall1}}, nil).Maybe()
 			},
 			Network: func(m *mock.Mock) {
 				m.On("FindNetwork", mock.Anything, nil).Return(&network.FindNetworkOK{Payload: network1}, nil).Maybe()


### PR DESCRIPTION
This results into many backend calls and the overall advantages are very small (only works for a set).