### PR TITLE
Provide custom metrics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ manager: generate fmt vet
 								   -X 'github.com/metal-stack/v.Revision=$(GITVERSION)' \
 								   -X 'github.com/metal-stack/v.GitSHA1=$(SHA)' \
 								   -X 'github.com/metal-stack/v.BuildDate=$(BUILDDATE)'" \
-						 -o bin/firewall-controller-manager main.go
+						 -o bin/firewall-controller-manager .
 	strip bin/firewall-controller-manager
 
 # Run against the mini-lab

--- a/health.go
+++ b/health.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func healthCheckFunc(log *slog.Logger, seedClient client.Client, namespace string) func(req *http.Request) error {
+	return func(req *http.Request) error {
+		log.Debug("health check called")
+
+		fws := &v2.FirewallList{}
+		err := seedClient.List(req.Context(), fws, client.InNamespace(namespace))
+		if err != nil {
+			return fmt.Errorf("unable to list firewalls in namespace %s", namespace)
+		}
+		return nil
+	}
+}

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 		log.Fatalf("unable to set up ready check %v", err)
 	}
 
-	mustRegisterCustomMetrics(l.WithGroup("metrics"), seedClient)
+	mustRegisterCustomMetrics(l.WithGroup("metrics"), seedClient, namespace)
 
 	var (
 		externalShootAccess = &v2.ShootAccess{

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 
@@ -39,19 +38,6 @@ import (
 const (
 	metalAuthHMACEnvVar = "METAL_AUTH_HMAC"
 )
-
-func healthCheckFunc(log *slog.Logger, seedClient client.Client, namespace string) func(req *http.Request) error {
-	return func(req *http.Request) error {
-		log.Debug("health check called")
-
-		fws := &v2.FirewallList{}
-		err := seedClient.List(req.Context(), fws, client.InNamespace(namespace))
-		if err != nil {
-			return fmt.Errorf("unable to list firewalls in namespace %s", namespace)
-		}
-		return nil
-	}
-}
 
 func main() {
 	var (

--- a/metrics.go
+++ b/metrics.go
@@ -32,10 +32,11 @@ type collector struct {
 	namespace  string
 }
 
-func mustRegisterCustomMetrics(log *slog.Logger, seedClient client.Client) {
+func mustRegisterCustomMetrics(log *slog.Logger, seedClient client.Client, namespace string) {
 	c := &collector{
 		log:        log,
 		seedClient: seedClient,
+		namespace:  namespace,
 	}
 
 	metrics.Registry.MustRegister(c)

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	v2 "github.com/metal-stack/firewall-controller-manager/api/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	firewallDeploymentReadyReplicasDesc = prometheus.NewDesc(
+		"firewall_deployment_ready_replicas",
+		"provide information on firewall deployment ready replicas",
+		[]string{"name", "namespace"},
+		nil,
+	)
+	firewallDeploymentTargetReplicasDesc = prometheus.NewDesc(
+		"firewall_deployment_target_replicas",
+		"provide information on firewall deployment target replicas",
+		[]string{"name", "namespace"},
+		nil,
+	)
+)
+
+type collector struct {
+	log        *slog.Logger
+	seedClient client.Client
+	namespace  string
+}
+
+func mustRegisterCustomMetrics(log *slog.Logger, seedClient client.Client) {
+	c := &collector{
+		log:        log,
+		seedClient: seedClient,
+	}
+
+	metrics.Registry.MustRegister(c)
+}
+
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- firewallDeploymentReadyReplicasDesc
+	ch <- firewallDeploymentTargetReplicasDesc
+}
+
+func (c *collector) Collect(ch chan<- prometheus.Metric) {
+	c.log.Info("collecting custom metrics")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	deploys := &v2.FirewallDeploymentList{}
+	err := c.seedClient.List(ctx, deploys, client.InNamespace(c.namespace))
+	if err != nil {
+		c.log.Error("unable to list firewall deployments", "error", err)
+		return
+	}
+
+	for _, deploy := range deploys.Items {
+		ch <- prometheus.MustNewConstMetric(firewallDeploymentReadyReplicasDesc, prometheus.GaugeValue,
+			float64(deploy.Status.ReadyReplicas),
+			deploy.Name,
+			deploy.Namespace,
+		)
+		ch <- prometheus.MustNewConstMetric(firewallDeploymentTargetReplicasDesc, prometheus.GaugeValue,
+			float64(deploy.Status.TargetReplicas),
+			deploy.Name,
+			deploy.Namespace,
+		)
+	}
+}


### PR DESCRIPTION
```
❯ curl -sSq localhost:2112/metrics | grep firewall_deployment 
# HELP firewall_deployment_ready_replicas provide information on firewall deployment ready replicas
# TYPE firewall_deployment_ready_replicas gauge
firewall_deployment_ready_replicas{name="shoot-firewall",namespace="shoot--pbs4kr--inttest10"} 1
# HELP firewall_deployment_target_replicas provide information on firewall deployment target replicas
# TYPE firewall_deployment_target_replicas gauge
firewall_deployment_target_replicas{name="shoot-firewall",namespace="shoot--pbs4kr--inttest10"} 1
```